### PR TITLE
Refactor (src/topics/posts.js:336): Function with many parameters (count = 4): incrementFieldAndUpdateSortedSet

### DIFF
--- a/src/topics/posts.js
+++ b/src/topics/posts.js
@@ -312,11 +312,11 @@ module.exports = function (Topics) {
 	};
 
 	Topics.increasePostCount = async function (tid) {
-		incrementFieldAndUpdateSortedSet(tid, 'postcount', 1, 'topics:posts');
+		await incrementFieldAndUpdateSortedSet({tid,field:'postcount', by:1, set:'topics:posts'});
 	};
 
 	Topics.decreasePostCount = async function (tid) {
-		incrementFieldAndUpdateSortedSet(tid, 'postcount', -1, 'topics:posts');
+		await incrementFieldAndUpdateSortedSet({tid, field:'postcount',by:-1,set: 'topics:posts'});
 	};
 
 	Topics.increaseViewCount = async function (req, tid) {
@@ -327,13 +327,13 @@ module.exports = function (Topics) {
 			const interval = meta.config.incrementTopicViewsInterval * 60000;
 			if (!req.session.tids_viewed[tid] || req.session.tids_viewed[tid] < now - interval) {
 				const cid = await Topics.getTopicField(tid, 'cid');
-				incrementFieldAndUpdateSortedSet(tid, 'viewcount', 1, ['topics:views', `cid:${cid}:tids:views`]);
+				await incrementFieldAndUpdateSortedSet({tid, field:'viewcount', by:1, set:['topics:views', `cid:${cid}:tids:views`]});
 				req.session.tids_viewed[tid] = now;
 			}
 		}
 	};
 
-	async function incrementFieldAndUpdateSortedSet(tid, field, by, set) {
+	async function incrementFieldAndUpdateSortedSet({tid, field, by, set}) {
 		const value = await db.incrObjectFieldBy(`topic:${tid}`, field, by);
 		await db[Array.isArray(set) ? 'sortedSetsAdd' : 'sortedSetAdd'](set, value, tid);
 	}


### PR DESCRIPTION
# P1B: Starter Task: Refactoring PR

> You are **not permitted** to use generative AI services (e.g., ChatGPT) to compose the answers.
> Any such use will be treated as a violation of academic integrity.

## 1. Issue 

**Link to the associated GitHub issue:**  

https://github.com/CMU-313/NodeBB/issues/48#issue-3376848450

**Full path to the refactored file:**

src/topics/posts.js

**What do you think this file does?**

I think this file affects posts inside of topics, for example, the view count,  adding or deleting posts. I gathered this information because I put a print statement inside of the function incrementFieldAndUpdateSortedSet and upon running nodeBB and checking the log, I could see that the print statement was triggered every time I added or deleted a post. I also hypothesized that the different parameters for incrementFieldAndUpdateSortedSet which are tid,field,by and set have to do with updating different parameters of a topic, with topic id, whether you want to increment a post count or view count, and how much by, and set for possibly which set to store this new value. I hypothesized the previous part based on checking where incrementFieldAndUpdateSortedSet was called in which was : Topics.increaseViewCount, Topics.decreasePostCount, and Topics.increasePostcount.

**What is the scope of your refactoring within that file?**

My refactoring affected incrementFieldAndUpdateSortedSet, Topics.increaseViewCount, Topics.decreasePostCount, and Topics.increasePostcount.

**Which Qlty‑reported issue did you address?**

336 Function with many parameters (count = 4): incrementFieldAndUpdateSortedSet

## 2. Refactoring

**How did the specific issue you chose impact the codebase’s adaptability?**

I would say that there is technically no impact on the codebase’s adaptability in the sense that changing the code to get rid of the smell does not change the code’s logic, but it does make the code cleaner. 

**What changes did you make to resolve the issue?**

 incrementFieldAndUpdateSortedSet originally had 4 parameters: tid,field,by and set. I changed the 4 parameters to 1 by using 1 object parameter : {tid,field,by,set}. I then changed all the areas where incrementFieldAndUpdatedSortedSet was called, so that I can change the parameters accordingly, just by setting each parameter to its respective field, e.g. incrementFieldAndUpdateSortedSet({tid,field:’postcount’,by:-1,set:’topics:posts’})


**How do your changes improve adaptability? Did you consider alternatives?**

The changes did not affect the code logic, so when I ran lint and test, the outcome was the same as before I refactored the code. However, I ran into a problem where sometimes running lint and test again multiple times in a row led to false outcomes, due to the port being used already, I also learned this is called flaky testing during oh.  I considered whether the fact that the function was asynchronous and used the await function and whether that affected it, so I added await to all the other calls, which led to the same outcome. 

## 3. Validation

**How did you trigger the refactored code path from the UI?**

I put a print statement right before any of the code inside of the  incrementFieldAndUpdateSortedSet function and made sure I was logged in as admin, and confirmed that when adding or deleting a post, the print statement was triggered in the nodebb log. 


**Attach a screenshot of the logs and UI demonstrating the trigger.**
*(Run `./nodebb log`; include the relevant UI view. Temporary logs should be removed before final commit.)*

<img width="2858" height="1699" alt="Screenshot 2025-09-03 181128" src="https://github.com/user-attachments/assets/1a5890c5-259f-4886-a8d1-46e9160ab2d0" />



**Attach a screenshot of `qlty smells --no-snippets <full/path/to/file.js>` showing fewer reported issues after the changes.**

<img width="1268" height="582" alt="Screenshot 2025-09-03 214044" src="https://github.com/user-attachments/assets/9cf41d62-5b13-4bb5-b59a-1567c7007fc5" />

