### PR TITLE
feat: add unread front end checkmark button to each topic post

### DIFF
--- a/public/src/client/topic.js
+++ b/public/src/client/topic.js
@@ -75,6 +75,7 @@ define('forum/topic', [
 		handleTopicSearch();
 
 		hooks.fire('action:topic.loaded', ajaxify.data);
+		addResolved_Status();
 	};
 
 	function handleTopicSearch() {
@@ -479,6 +480,46 @@ define('forum/topic', [
 			alerts.remove('bookmark');
 		}
 	}
+
+	function addResolved_Status() { 
+		//used claude for base function logic, then I changed more based on my personal goal.
+		// iterate through each topic post and add unresolved status with checkmark
+		$('[component="post"]').each(function () {
+			// this current post
+			const post_elem = $(this);
+			const isResolved = false;
+			const currStatus = $(`
+				<div class="post-toggle" style="cursor: pointer; padding: 5px; margin: 5px; display: flex; align-items: center; gap: 8px;">
+					<div class="checkbox" style="width: 15px; height: 15px; border: 2px solid #999; display: inline-block; text-align: center; line-height: 12px; font-size: 12px;">
+						${isResolved ? '✓' : ''}
+					</div>
+					<span class="current_status" style="color: ${isResolved ? 'green' : 'red'}">
+						${isResolved ? 'resolved' : 'unresolved'}
+					</span>
+				</div>
+			`);
+
+			//change status if clicked on
+			currStatus.on('click', function () {
+				const checkbox_elem = $(this).find('.checkbox'); //finds any element with checkbox class
+				const statusText_elem = $(this).find('.current_status'); //finds any eleemnt with current status class
+				const currentStatus = checkbox_elem.text().trim() === '✓';
+				const updatedStatus = !currentStatus;
+				
+				// Update checkbox
+				checkbox_elem.text(updatedStatus ? '✓' : '');
+				
+				// Update status text and color
+				statusText_elem.text(updatedStatus ? 'resolved' : 'unresolved');
+				statusText_elem.css('color', updatedStatus ? 'green' : 'red');
+			
+				// later update to only course staff can check
+			});
+			
+			
+			post_elem.prepend(currStatus);
+		});
+	} 
 
 
 	return Topic;


### PR DESCRIPTION
# Name of PR: feat: add unread front end checkmark button to each topic post

## 1. Issue

**Link to the associated GitHub issue:**
issue #11 
user story #16 


## 2. Changes

**What changes did you make to resolve the issue?**

So far, I have changed [create.js](http://create.js/) (backend), and [topic.js](http://topic.js/) (front end). For [create.js](http://create.js/), I added a data.resolved = false so later, the resolved status can be preserved and remembered through the internal code/backend code. For [topic.js](http://topic.js/), I added a function called addResolvedStatus that takes care of front end additions (iterating through each post, and creating a singular button that marks unresolved or resolved).



**Does your change introduce new dependencies to this project? If so, list here.**
- Yes, before I start issue #36, I must have created unresolved/resolved posts. 


## 3. Validation

**How did you trigger the change to show that it is working?**
- I tested my changes by first, finding where in the code is being affected. I saw that [create.js](http://create.js/) is the main place where topics are created by adding console.log statements and checking the nodebb log and the front end console log through inspect and observing the reaction after creating new topics. Then after finding where to implement the additions, I checked that every existing topic has the same unresolved/resolved button that accurately switched from resolved to unresolved or vice versa from clicking in the box, and I also checked that when creating a new topic, that addition is there. 


**Attach screenshot(s) of the logs and UI demonstrating the change.**

Testing if when creating new topic post, unresolved/resolved button still shows up:

[
<img width="901" height="559" alt="Screenshot 2025-09-25 113823" src="https://github.com/user-attachments/assets/7eed8231-aad2-4ec1-9526-e402923b422e" />
<img width="889" height="601" alt="Screenshot 2025-09-25 113833" src="https://github.com/user-attachments/assets/a4e7925d-6480-4516-9475-a3018fbdc6a7" />
](url)

Check if existing topic already has unresolved/resolved button:

<img width="641" height="494" alt="Screenshot 2025-09-25 114009" src="https://github.com/user-attachments/assets/9b74a6ea-f2d5-4f3f-9f1f-f28ea764cf17" />






