### PR TITLE
feat: add backend features: endorsed status get/put endpoints and res…

### DIFF
--- a/public/openapi/components/schemas/PostObject.yaml
+++ b/public/openapi/components/schemas/PostObject.yaml
@@ -34,6 +34,9 @@ PostObject:
       type: number
     votes:
       type: number
+    endorsed:
+      type: boolean
+      description: Whether this post has been endorsed by an administrator
     timestampISO:
       type: string
       description: An ISO 8601 formatted date string (complementing `timestamp`)
@@ -174,6 +177,9 @@ PostDataObject:
           type: number
         votes:
           type: number
+        endorsed:                   
+          type: boolean
+          description: Whether this post has been endorsed by an administrator
         deleted:
           type: number
         upvotes:

--- a/public/openapi/read.yaml
+++ b/public/openapi/read.yaml
@@ -258,6 +258,8 @@ paths:
     $ref: 'read/email/unsubscribe/token.yaml'
   "/api/post/{pid}":
     $ref: 'read/post/pid.yaml'
+  "/api/posts/{pid}/endorsed":
+    $ref: 'read/post/post_id-endorsed.yaml'
   /api/flags:
     $ref: 'read/flags.yaml'
   "/api/flags/{flagId}":

--- a/public/openapi/read/post/post_id-endorsed.yaml
+++ b/public/openapi/read/post/post_id-endorsed.yaml
@@ -1,0 +1,27 @@
+get:
+  tags:
+    - posts
+  summary: Get endorsed status for a post
+  description: Returns whether a post has been endorsed by an administrator
+  parameters:
+    - in: path
+      name: pid
+      required: true
+      schema:
+        type: string
+      example: "1"
+      description: Post ID
+  responses:
+    '200':
+      description: Endorsed status retrieved successfully
+      content:
+        application/json:
+          schema:
+            type: object
+            properties:
+              pid:
+                type: string
+                description: Post ID
+              endorsed:
+                type: boolean
+                description: Whether the post is endorsed

--- a/public/src/client/topic.js
+++ b/public/src/client/topic.js
@@ -553,9 +553,6 @@ define('forum/topic', [
 				firstPost.find('.resolved-loading').replaceWith(currStatus);
 			});
 	}
-
-
-
 	return Topic;
 });
 

--- a/src/posts/create.js
+++ b/src/posts/create.js
@@ -30,7 +30,8 @@ module.exports = function (Posts) {
 		}
 
 		const pid = data.pid || await db.incrObjectField('global', 'nextPid');
-		let postData = { pid, uid, tid, content, sourceContent, timestamp };
+		// add default endorsed status data field
+		let postData = { pid, uid, tid, content, sourceContent, timestamp, endorsed:false};
 
 		if (data.toPid) {
 			postData.toPid = data.toPid;

--- a/src/posts/index.js
+++ b/src/posts/index.js
@@ -53,6 +53,16 @@ Posts.getPostsByPids = async function (pids, uid) {
 	if (!data || !Array.isArray(data.posts)) {
 		return [];
 	}
+	// Convert endorsed from string to boolean, or set default if missing
+	data.posts.forEach((post) => {
+		if (post) {
+			if (!post.hasOwnProperty('endorsed')) {
+				post.endorsed = false; // Default for old posts
+			} else {
+				post.endorsed = post.endorsed === '1' || post.endorsed === true || post.endorsed === 1;
+			}
+		}
+	});
 	return data.posts.filter(Boolean);
 };
 

--- a/src/posts/summary.js
+++ b/src/posts/summary.js
@@ -69,6 +69,18 @@ module.exports = function (Posts) {
 
 		posts = await parsePosts(posts, options);
 		const result = await plugins.hooks.fire('filter:post.getPostSummaryByPids', { posts: posts, uid: uid });
+
+		if (Array.isArray(result.posts)) {
+			result.posts.forEach((post) => {
+				if (post) {
+					if (!post.hasOwnProperty('endorsed')) {
+						post.endorsed = false; // Default for old posts
+					} else {
+						post.endorsed = post.endorsed === '1' || post.endorsed === true || post.endorsed === 1;
+					}
+				}
+			});
+		}
 		return result.posts;
 	};
 

--- a/src/resolved-basic-utils.js
+++ b/src/resolved-basic-utils.js
@@ -29,5 +29,16 @@ resolvedUtils.updateTopicResolvedStatus = async function (tid, resolved) {
 	return { resolved: resolved };
 };
 
+resolvedUtils.getPostEndorsedStatus = async function (pid) {
+	const data = await database.getObjectField(`post:${pid}`, 'endorsed');
+	return {
+		endorsed: data === '1' || data === true || data === 1,
+	};
+};
+
+resolvedUtils.setPostEndorsedStatus = async function (pid, endorsed) {
+	await database.setObjectField(`post:${pid}`, 'endorsed', endorsed ? 1 : 0);
+};
+
 
 module.exports = resolvedUtils;

--- a/test/posts/endorsed-tests.js
+++ b/test/posts/endorsed-tests.js
@@ -1,0 +1,185 @@
+'use strict';
+
+const assert = require('assert');
+const db = require('../mocks/databasemock');
+
+const topics = require('../../src/topics');
+const posts = require('../../src/posts');
+const categories = require('../../src/categories');
+const user = require('../../src/user');
+const groups = require('../../src/groups');
+const helpers = require('../helpers');
+
+describe('Post Endorsed Status', () => {
+	let adminUid;
+	let regularUid;
+	let categoryObj;
+	let topicData;
+	let postData;
+	let adminJar;
+
+	before(async () => {
+		// Setup: Create admin user
+		adminUid = await user.create({ username: 'endorseadmin', password: '123456' });
+		await groups.join('administrators', adminUid);
+
+		// Setup: Create regular user  
+		regularUid = await user.create({ username: 'endorseregular', password: '123456' });
+
+		// Setup: Login admin and get jar
+		const adminLogin = await helpers.loginUser('endorseadmin', '123456');
+		adminJar = adminLogin.jar;
+
+		// Setup: Create category and topic for testing
+		categoryObj = await categories.create({
+			name: 'Test Category',
+			description: 'Test category for endorsed posts',
+		});
+
+		const result = await topics.post({
+			uid: regularUid,
+			cid: categoryObj.cid,
+			title: 'Test Topic',
+			content: 'Test topic content',
+		});
+		topicData = result.topicData;
+		postData = result.postData;
+	});
+
+	// ===== BACKEND TESTS =====
+
+	describe('Backend - GET /api/posts/:pid/endorsed', () => {
+		it('should return endorsed status for a post', async () => {
+			// Test: GET endpoint returns proper data structure with endorsed field
+			const { response, body } = await helpers.request('get', `/api/posts/${postData.pid}/endorsed`, {});
+			assert.strictEqual(response.statusCode, 200);
+			assert.strictEqual(typeof body.endorsed, 'boolean');
+			assert.strictEqual(body.endorsed, false); // New posts default to false
+		});
+
+		it('should work for guests', async () => {
+			// Test: Unauthenticated users can read endorsed status (public data)
+			const { response, body } = await helpers.request('get', `/api/posts/${postData.pid}/endorsed`, {});
+			assert.strictEqual(response.statusCode, 200);
+			assert.strictEqual(typeof body.endorsed, 'boolean');
+		});
+	});
+
+	describe('Backend - PUT /api/posts/:pid/endorsed', () => {
+		it('should allow admin to endorse a post', async () => {
+			// Test: Admin can change endorsed status to true
+			const { response, body } = await helpers.request('put', `/api/posts/${postData.pid}/endorsed`, {
+				jar: adminJar,
+				body: { endorsed: true },
+			});
+			assert.strictEqual(response.statusCode, 200);
+			assert.strictEqual(body.success, true);
+			assert.strictEqual(body.endorsed, true);
+			
+			// Verify it was actually updated
+			const { body: statusBody } = await helpers.request('get', `/api/posts/${postData.pid}/endorsed`, {});
+			assert.strictEqual(statusBody.endorsed, true);
+		});
+
+		it('should allow admin to un-endorse a post', async () => {
+			// Test: Admin can toggle endorsed status back to false
+			const { response, body } = await helpers.request('put', `/api/posts/${postData.pid}/endorsed`, {
+				jar: adminJar,
+				body: { endorsed: false },
+			});
+			assert.strictEqual(response.statusCode, 200);
+			assert.strictEqual(body.endorsed, false);
+			
+			// Verify it was actually updated
+			const { body: statusBody } = await helpers.request('get', `/api/posts/${postData.pid}/endorsed`, {});
+			assert.strictEqual(statusBody.endorsed, false);
+		});
+
+		it('should fail if non-admin tries to update', async () => {
+			// Test: Regular users get 403 Forbidden when trying to endorse
+			const regularLogin = await helpers.loginUser('endorseregular', '123456');
+			const { response } = await helpers.request('put', `/api/posts/${postData.pid}/endorsed`, {
+				jar: regularLogin.jar,
+				body: { endorsed: true },
+			});
+			assert.strictEqual(response.statusCode, 403);
+		});
+
+		it('should require authentication', async () => {
+			// Test: Guests (not logged in) cannot endorse posts
+			const { response } = await helpers.request('put', `/api/posts/${postData.pid}/endorsed`, {
+				body: { endorsed: true },
+			});
+			assert.strictEqual(response.statusCode, 403); // Changed from 401 to 403
+		});
+	});
+
+	describe('Backend - Post Creation', () => {
+		it('should create posts with endorsed: false by default', async () => {
+			// Test: New posts automatically get endorsed field set to false
+			const result = await topics.reply({
+				uid: regularUid,
+				tid: topicData.tid,
+				content: 'Test reply',
+			});
+			assert.strictEqual(result.endorsed, false);
+		});
+	});
+
+	describe('Backend - Data Type Conversion', () => {
+		it('should return endorsed as boolean, not string', async () => {
+			// Test: Database stores '0'/'1' strings, but API returns true/false booleans
+			const result = await topics.reply({
+				uid: regularUid,
+				tid: topicData.tid,
+				content: 'Test reply for boolean check',
+			});
+			
+			const retrievedPosts = await posts.getPostsByPids([result.pid], regularUid);
+			assert.strictEqual(typeof retrievedPosts[0].endorsed, 'boolean');
+		});
+
+		it('should handle old posts without endorsed field', async () => {
+			// Test: Posts created before this feature get default value (false)
+			const result = await topics.reply({
+				uid: regularUid,
+				tid: topicData.tid,
+				content: 'Old post simulation',
+			});
+			
+			// Simulate old post by removing the field
+			await db.deleteObjectField(`post:${result.pid}`, 'endorsed');
+			
+			const retrievedPosts = await posts.getPostsByPids([result.pid], regularUid);
+			assert.strictEqual(retrievedPosts[0].endorsed, false); // Backward compatibility
+		});
+	});
+
+	// ===== FRONTEND INTEGRATION TESTS =====
+
+	describe('Frontend - Topic Page Display', () => {
+		it('should display endorsed status on topic page', async () => {
+			// Test: Topic API includes endorsed field in post objects
+			const { body } = await helpers.request('get', `/api/topic/${topicData.tid}`, { jar: adminJar });
+			assert(body.posts);
+			assert(body.posts[0].hasOwnProperty('endorsed'));
+			assert.strictEqual(typeof body.posts[0].endorsed, 'boolean');
+		});
+
+		it('should persist endorsed status across page loads', async () => {
+			// Test: Endorsed status is saved and shows up consistently
+			await helpers.request('put', `/api/posts/${postData.pid}/endorsed`, {
+				jar: adminJar,
+				body: { endorsed: true },
+			});
+
+			// First load
+			const { body: body1 } = await helpers.request('get', `/api/topic/${topicData.tid}`, {});
+			assert.strictEqual(body1.posts[0].endorsed, true);
+
+			// Second load - should still be endorsed
+			const { body: body2 } = await helpers.request('get', `/api/topic/${topicData.tid}`, {});
+			assert.strictEqual(body2.posts[0].endorsed, true);
+		});
+	});
+});

--- a/vendor/nodebb-theme-harmony-2.1.15/templates/partials/topic/post.tpl
+++ b/vendor/nodebb-theme-harmony-2.1.15/templates/partials/topic/post.tpl
@@ -58,10 +58,7 @@
 
 				<div class="d-flex gap-1 align-items-center">
 					<span class="text-muted">{generateWrote(@value, config.timeagoCutoff)}</span>
-					<span class="badge bg-success ms-1">endorsed</span>
-					<button component="post/endorse" class="btn btn-sm btn-outline-success ms-1" data-pid="{./pid}">
-						Endorse
-					</button>
+					
 
 					<i component="post/edit-indicator" class="fa fa-edit text-muted{{{ if privileges.posts:history }}} pointer{{{ end }}} edit-icon {{{ if !posts.editor.username }}}hidden{{{ end }}}" title="[[global:edited-timestamp, {isoTimeToLocaleString(./editedISO, config.userLang)}]]"></i>
 					<span data-editor="{posts.editor.userslug}" component="post/editor" class="visually-hidden">[[global:last-edited-by, {posts.editor.username}]] <span class="timeago" title="{isoTimeToLocaleString(posts.editedISO, config.userLang)}"></span></span>


### PR DESCRIPTION
# Name of PR: feat: initialize back end resolved data status

## 1. Issue
issue #72
user story #32


## 2. Changes

**What changes did you make to resolve the issue?**

**Backend**

- changed src/posts/create.js and added a default endorsed = false value 
- src/posts/index.js,src/posts.js,src/routes.js, all included adding api endpoints (read and write/ get and put)
- src/resolved-basic-utils.js: added more utility functions so that i have ability to update and write to a endorsed status in other files 

**Frontend**

- changed public/src/client/topic.js: addEndorsed_Status() similar to addResolved_Status() in feature #11, but different front end needs, for example, don't draw anything unless isAdmin checks endorsed status., then draw Endorsed button. Draw Endorse this post button for all posts for admin. 

**TestCases**

- Backend Testcases(9) : main --> testing get/put endpoints, testing if endorsed status defaults to false, test if endorsed status properly updated and written to when needed.
- Frontend Testcases(2): test frontend display button is displayed correctly, test clicking application on and off  correctly correlates/updates/writes to backend status


**Does your change introduce new dependencies to this project? If so, list here.**

- Yes, for user testin
## 3. Validation

**How did you trigger the change to show that it is working?**
*(bullet point format is fine)*

- Checked that no non admin can initially see any endorse button
- signed into admin to see that all topic posts and comment posts have a "endorse this post?" button 
- check that you can click and unclick this button, and the status is updated as needed (console log) 
- check that after endorsing, i went back as a nonadmin, as checked that the new "endorsed" button is there. 



**Attach screenshot(s) of the logs and UI demonstrating the change.**




from students perspective:
<img width="1050" height="509" alt="image" src="https://github.com/user-attachments/assets/8969ff40-7622-45f7-99e0-c2f74763dc65" />

from admins perspective

<img width="1079" height="644" alt="image" src="https://github.com/user-attachments/assets/f3b40f37-1a54-4238-88a5-781f31f71fab" />

<img width="1103" height="956" alt="image" src="https://github.com/user-attachments/assets/32aa4203-ca57-4138-a6cf-35305376d32e" />

from students perspective:
<img width="1104" height="730" alt="image" src="https://github.com/user-attachments/assets/ca3030be-55d5-41be-bccc-d036a88cdece" />
