### PR TITLE
Fix: Mitigate timeout when in CI

### DIFF
--- a/test/activitypub.js
+++ b/test/activitypub.js
@@ -18,6 +18,16 @@ const topics = require('../src/topics');
 const posts = require('../src/posts');
 const activitypub = require('../src/activitypub');
 
+// CI-specific stub to prevent hanging ActivityPub network calls
+if (process.env.CI) {
+	console.log('[CI] Stubbing ActivityPub follow/unfollow and remote fetches to prevent hangs');
+	const ap = require('../src/activitypub');
+	ap.fetchRemoteObject = async () => null;
+	ap.postToInbox = async () => ({ status: 'stubbed' });
+	ap.send = async () => ({ status: 'stubbed' });
+}
+
+
 describe('ActivityPub integration', () => {
 	before(async () => {
 		meta.config.activitypubEnabled = 1;


### PR DESCRIPTION
# Fix: mitigate timeout when in CI

## 1. Issue

**Link to the associated GitHub/Notion issue:**
- the previous fix (https://github.com/CMU-313/nodebb-fall-2025-jack/pull/75) did not cover all necessary activitypub calls, and Jerry's PR failed with a different activity pub issue. This pr will aim to solve that.


## 2. Changes

**What changes did you make to resolve the issue?**
- Use a stub for ActivityPub when in CI

**Does your change introduce new dependencies to this project? If so, list here.**
- No

## 3. Validation

**How did you trigger the change to show that it is working?**
- This PR passed locally and on GitHub. If it also passes tests on GitHub after being merged with main, then we've solved the issue.